### PR TITLE
Make sure simple enum cases are serialized the same as in zio-schema

### DIFF
--- a/zio-http-rust/src/scala/zio/http/rust/printer/RustClient.scala
+++ b/zio-http-rust/src/scala/zio/http/rust/printer/RustClient.scala
@@ -176,7 +176,7 @@ object RustClient:
     Printer.byValue:
       case (status, (RustEndpoint.EndpointErrorCase.Simple(cname), n, errorType)) =>
         indent(3) ~ name(n) ~ dcolon ~ str(s"Status${status}") ~~ str("=>") ~~ str("Some") ~ parentheses(
-          typename(errorType) ~ dcolon ~ name(cname)
+          typename(errorType) ~ dcolon ~ name(cname) ~~ str("{}")
         ) ~ comma ~ newline
       case (status, (RustEndpoint.EndpointErrorCase.Inlined(fields, cname, _, _, _), n, errorType)) =>
         indent(3) ~ name(n) ~ dcolon ~ str(s"Status${status}") ~~ ch('{') ~~ structFieldPatterns(fields) ~~ ch('}') ~~ str("=>") ~~


### PR DESCRIPTION
Because of the rules described at https://serde.rs/json.html simple enum cases like

```rust
enum Type {
   U32
}
```
were serialized as strings in the generated client (`"U32"`) while zio-schema represents them as empty tagged objects:

```json
"U32": {}
```

By generating a less ergonomic version of these types:

```rust
enum Type {
   U32 {}
}
```

the serialization format becomes compatible.