### PR TITLE
Fix capturing both side of fallback in endpoint outputs

### DIFF
--- a/zio-http-rust/src/scala/zio/http/rust/RustEndpoint.scala
+++ b/zio-http-rust/src/scala/zio/http/rust/RustEndpoint.scala
@@ -460,6 +460,8 @@ object RustEndpoint:
         for
           _ <- updateState(_.startPossibleOutput(isError))
           _ <- addOutput(left, isError)
+          _ <- updateState(_.finishPossibleOutput())
+          _ <- updateState(_.startPossibleOutput(isError))
           _ <- addOutput(right, isError)
           _ <- updateState(_.finishPossibleOutput())
         yield ()

--- a/zio-http-rust/src/scala/zio/http/rust/printer/RustClient.scala
+++ b/zio-http-rust/src/scala/zio/http/rust/printer/RustClient.scala
@@ -63,8 +63,7 @@ object RustClient:
          else Printer.unit) ~
         (
           if endpoint.bodies.size == 1 then
-            if endpoint.bodies.head._2 == Types.intoBody then
-              indent(3) ~ str(".body") ~ parentheses(name(endpoint.bodies.head._1)) ~ newline
+            if endpoint.bodies.head._2 == Types.intoBody then indent(3) ~ str(".body") ~ parentheses(name(endpoint.bodies.head._1)) ~ newline
             else indent(3) ~ str(".json") ~ parentheses(ch('&') ~ name(endpoint.bodies.head._1)) ~ newline
           else if endpoint.bodies.size > 1 then indent(3) ~ str(".multipart(form)") ~ newline
           else Printer.unit


### PR DESCRIPTION
Endpoint's output codec `Fallback`s were not handled properly, leading to one of the alternatives got lost.