### PR TITLE
escape path segments

### DIFF
--- a/zio-http-rust/src/scala/zio/http/rust/RustEndpoint.scala
+++ b/zio-http-rust/src/scala/zio/http/rust/RustEndpoint.scala
@@ -143,23 +143,6 @@ final case class RustEndpoint(
             .derive(RustType.deserialize)
     ).flatten
 
-  def pathExpression: String =
-    if pathSegments.forall(_.isLiteral) then
-      """"""" +
-        pathSegments
-          .collect:
-            case RustPathSegment.Literal(value) => value
-          .mkString("/") + """""""
-    else
-      """&format!("""" +
-        pathSegments
-          .map:
-            case RustPathSegment.Trailing           => "{path}"
-            case RustPathSegment.Parameter(name, _) => "{" + name.toSnakeCase.asString + "}"
-            case RustPathSegment.Literal(value)     => value
-          .mkString("/") +
-        """")"""
-
   def toEndpoints: RustEndpoints =
     RustEndpoints(Name.fromString("Api"), Chunk(this))
 


### PR DESCRIPTION
Fix #6 

Instead of `url.set_path(&format!("v1/projects/{project_id}"));` generate safe escaped version:

```rust
        url.path_segments_mut().unwrap()
            .push("v1")
            .push("projects")
            .push(project_id);
```